### PR TITLE
examples: Fix build for get_public_key API

### DIFF
--- a/examples/interaction.rs
+++ b/examples/interaction.rs
@@ -37,11 +37,11 @@ fn do_main() -> Result<(), trezor::Error> {
 	trezor.init_device()?;
 
 	let xpub = handle_interaction(trezor.get_public_key(
-		vec![
+		&vec![
 			bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 			bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 			bip32::ChildNumber::from_hardened_idx(0).unwrap(),
-		],
+		].into(),
 		trezor::protos::InputScriptType::SPENDADDRESS,
 		Network::Testnet,
 		true,

--- a/examples/sign_message.rs
+++ b/examples/sign_message.rs
@@ -55,11 +55,11 @@ fn main() {
 	let pubkey = handle_interaction(
 		trezor
 			.get_public_key(
-				vec![
+				&vec![
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(1).unwrap(),
-				],
+				].into(),
 				trezor::protos::InputScriptType::SPENDADDRESS,
 				Network::Testnet,
 				true,
@@ -73,11 +73,11 @@ fn main() {
 		trezor
 			.sign_message(
 				"regel het".to_owned(),
-				vec![
+				&vec![
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(1).unwrap(),
-				],
+				].into(),
 				InputScriptType::SPENDADDRESS,
 				Network::Testnet,
 			)

--- a/examples/sign_tx.rs
+++ b/examples/sign_tx.rs
@@ -76,11 +76,11 @@ fn main() {
 	let pubkey = handle_interaction(
 		trezor
 			.get_public_key(
-				vec![
+				&vec![
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(0).unwrap(),
 					bip32::ChildNumber::from_hardened_idx(1).unwrap(),
-				],
+				].into(),
 				trezor::protos::InputScriptType::SPENDADDRESS,
 				Network::Testnet,
 				true,


### PR DESCRIPTION
Getting a public key takes a DerivationPath instead of a vector of ChildIndex